### PR TITLE
1.18.0: Restore configs and View Diff

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = hyprkcs-git
 	pkgdesc = A fast, minimal Hyprland keybind cheat sheet and editor written in Rust/GTK4
-	pkgver = 1.17.0
+	pkgver = 1.18.0
 	pkgrel = 1
 	url = https://github.com/kosa12/hyprKCS
 	arch = x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyprKCS"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -657,6 +657,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "similar",
 ]
 
 [[package]]
@@ -1003,6 +1004,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprKCS"
-version = "1.17.0"
+version = "1.18.0"
 edition = "2021"
 license = "MIT"
 
@@ -17,6 +17,7 @@ fuzzy-matcher = "0.3.7"
 chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+similar = { version = "2.7.0", features = ["inline"] }
 
 [[bin]]
 name = "hyprKCS"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kosa Matyas <kosa03matyas@gmail.com>
 pkgname=hyprkcs-git
-pkgver=1.17.0
+pkgver=1.18.0
 pkgrel=1
 pkgdesc="A fast, minimal Hyprland keybind cheat sheet and editor written in Rust/GTK4"
 arch=('x86_64')

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ hyprKCS provides a simple and intuitive interface to view, edit, and manage your
 - **Conflict Detection**: Automatically identifies and highlights duplicate keybinds, resolving Hyprland variables (e.g., `$mainMod`) for accuracy.
 - **Full Keybind Management**: Add, edit, and delete keybinds directly from the UI. Changes are written back to the correct configuration files.
 - **Configuration Backup**: Create a timestamped backup of your configuration files with a single click or set the automatic backup behavior in the settings (it's set to true by default).
+- **Interactive Restore**: Easily browse previous backups and restore your entire configuration tree with a single click.
+- **Visual Diffs**: Compare any backup with your current configuration using a Git-style color-coded diff view before restoring.
 - **Conflict Resolution Wizard**: A guided tool to help resolve duplicate keybinds one by one.
 - **Smart Autocomplete**: Suggests valid Hyprland dispatchers as you type.
 - **Favorites**: Pin frequently used keybinds for quick access.
@@ -170,6 +172,13 @@ Manage your system's input behavior without manual text editing.
 - **Keyboard Settings**: Set your layout code, variant, options, repeat rate, and delay.
 - **Mouse/Touchpad**: Adjust mouse sensitivity and window focus behavior (Follow Mouse).
 - **Direct Save**: Changes are written directly to your `hyprland.conf` input block.
+
+**Backup and Restore**
+Safely manage your configuration versions.
+- **Full Tree Backup**: Backs up your entire `~/.config/hypr` directory recursively, preserving folder structures and external scripts.
+- **Interactive Restore**: Access the Restore menu from Settings to see all available timestamped backups.
+- **Visual Diffs**: Before restoring, click "View Diff" to see a color-coded comparison (additions/removals) between the backup and your current files.
+- **One-Click Recovery**: Restore your entire setup instantly if a change breaks your workflow.
 
 <p align="center">
     <img src="./assets/image_4.png" width="80%" />

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "hyprkcs";
-            version = "1.17.0";
+            version = "1.18.0";
 
             src = let
               fs = pkgs.lib.fileset;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -18,6 +18,7 @@ pub fn create_settings_view(
     on_submap_toggle: Rc<dyn Fn(bool)>,
     on_sort_change: Rc<dyn Fn(String)>,
     on_show_toast: Rc<dyn Fn(String)>,
+    on_restore_clicked: Rc<dyn Fn()>,
 ) -> gtk::Widget {
     let config = Rc::new(RefCell::new(StyleConfig::load()));
 
@@ -159,6 +160,24 @@ pub fn create_settings_view(
     });
     group_backup.add(&max_backups_row);
     group_backup.add(&count_row);
+
+    let restore_row = adw::ActionRow::builder()
+        .title("Restore Backup")
+        .subtitle("Restore configuration from a previous backup")
+        .activatable(true)
+        .build();
+
+    let restore_icon = gtk::Image::from_icon_name("document-revert-symbolic");
+    restore_row.add_prefix(&restore_icon);
+
+    let restore_suffix = gtk::Image::from_icon_name("go-next-symbolic");
+    restore_row.add_suffix(&restore_suffix);
+
+    let on_restore = on_restore_clicked.clone();
+    restore_row.connect_activated(move |_| {
+        on_restore();
+    });
+    group_backup.add(&restore_row);
 
     page_general.add(&group_backup);
 

--- a/src/ui/utils/mod.rs
+++ b/src/ui/utils/mod.rs
@@ -5,7 +5,7 @@ pub mod keybinds;
 pub mod search;
 pub mod widgets;
 
-pub use backup::perform_backup;
+pub use backup::{generate_diff, list_backups, perform_backup, restore_backup};
 pub use execution::{command_exists, execute_keybind};
 pub use export::export_keybinds_to_markdown;
 pub use keybinds::{normalize, reload_keybinds};

--- a/src/ui/views/mod.rs
+++ b/src/ui/views/mod.rs
@@ -2,7 +2,9 @@ mod add;
 mod edit;
 mod keyboard;
 pub mod keyboard_layouts;
+mod restore;
 
 pub use add::create_add_view;
 pub use edit::create_edit_view;
 pub use keyboard::create_keyboard_view;
+pub use restore::create_restore_view;

--- a/src/ui/views/restore.rs
+++ b/src/ui/views/restore.rs
@@ -1,0 +1,340 @@
+use crate::ui::utils::{generate_diff, list_backups, restore_backup};
+use gtk::glib::translate::IntoGlib;
+use gtk::prelude::*;
+use gtk4 as gtk;
+use libadwaita as adw;
+
+pub fn create_restore_view(
+    stack: &gtk::Stack,
+    model: &gtk::gio::ListStore,
+    toast_overlay: &adw::ToastOverlay,
+    restore_container: &gtk::Box,
+) -> gtk::Widget {
+    let container = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(12)
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .vexpand(true)
+        .build();
+
+    let outer_scroll = gtk::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vexpand(true)
+        .child(&container)
+        .build();
+
+    // Header
+    let header_box = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+
+    let back_btn = gtk::Button::builder()
+        .icon_name("go-previous-symbolic")
+        .css_classes(["flat", "circular"])
+        .tooltip_text("Back to Settings")
+        .build();
+
+    let stack_c = stack.clone();
+    back_btn.connect_clicked(move |_| {
+        stack_c.set_visible_child_name("settings");
+    });
+
+    let title_box = gtk::Box::new(gtk::Orientation::Vertical, 4);
+    let title = gtk::Label::builder()
+        .label("Restore Backup")
+        .css_classes(["title-1"])
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .build();
+    let subtitle = gtk::Label::builder()
+        .label("Select a backup to restore your configuration. This will overwrite current files.")
+        .css_classes(["dim-label"])
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .build();
+
+    let warning = gtk::Label::builder()
+        .label("WARNING: YOU COULD LOSE EVERYTHING CHANGED SINCE THE LAST BACKUP.")
+        .css_classes(["error", "caption"])
+        .halign(gtk::Align::Start)
+        .margin_bottom(12)
+        .wrap(true)
+        .build();
+
+    title_box.append(&title);
+    title_box.append(&subtitle);
+    title_box.append(&warning);
+
+    header_box.append(&back_btn);
+    header_box.append(&title_box);
+    container.append(&header_box);
+
+    let scroll = gtk::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vexpand(true)
+        .build();
+
+    let list_box = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(8)
+        .build();
+    scroll.set_child(Some(&list_box));
+    container.append(&scroll);
+
+    let backups = list_backups().unwrap_or_default();
+
+    if backups.is_empty() {
+        let no_backups = adw::StatusPage::builder()
+            .title("No Backups Found")
+            .description("You haven't created any backups yet.")
+            .icon_name("document-open-recent-symbolic")
+            .vexpand(true)
+            .build();
+        list_box.append(&no_backups);
+    } else {
+        for path in backups {
+            let row = create_backup_row(&path, stack, model, toast_overlay, restore_container);
+            list_box.append(&row);
+        }
+    }
+
+    outer_scroll.upcast()
+}
+
+fn create_backup_row(
+    path: &std::path::PathBuf,
+    stack: &gtk::Stack,
+    model: &gtk::gio::ListStore,
+    toast_overlay: &adw::ToastOverlay,
+    restore_container: &gtk::Box,
+) -> gtk::Widget {
+    let row = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(12)
+        .css_classes(["card"])
+        .margin_start(4)
+        .margin_end(4)
+        .build();
+
+    let info_box = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(4)
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .hexpand(true)
+        .build();
+
+    let timestamp = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    let title = gtk::Label::builder()
+        .label(&timestamp)
+        .halign(gtk::Align::Start)
+        .css_classes(["heading"])
+        .build();
+
+    let path_label = gtk::Label::builder()
+        .label(path.to_string_lossy().to_string())
+        .halign(gtk::Align::Start)
+        .css_classes(["caption", "dim-label"])
+        .ellipsize(gtk::pango::EllipsizeMode::Middle)
+        .max_width_chars(40)
+        .wrap(true)
+        .build();
+
+    info_box.append(&title);
+    info_box.append(&path_label);
+    row.append(&info_box);
+
+    let actions_box = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(6)
+        .valign(gtk::Align::Center)
+        .margin_end(12)
+        .build();
+
+    let diff_btn = gtk::Button::builder()
+        .label("View Diff")
+        .css_classes(["pill"])
+        .build();
+
+    let restore_btn = gtk::Button::builder()
+        .label("Restore")
+        .css_classes(["destructive-action", "pill"])
+        .build();
+
+    actions_box.append(&diff_btn);
+    actions_box.append(&restore_btn);
+    row.append(&actions_box);
+
+    let path_c = path.clone();
+    let toast_c = toast_overlay.clone();
+    let stack_c = stack.clone();
+    let model_c = model.clone();
+
+    restore_btn.connect_clicked(move |_| {
+        let p = path_c.clone();
+        let t = toast_c.clone();
+        let s = stack_c.clone();
+        let m = model_c.clone();
+
+        match restore_backup(&p) {
+            Ok(msg) => {
+                let toast = adw::Toast::new(&format!("Restore successful: {}", msg));
+                t.add_toast(toast);
+                crate::ui::utils::reload_keybinds(&m);
+                crate::ui::style::reload_style();
+                s.set_visible_child_name("home");
+            }
+            Err(e) => {
+                let toast = adw::Toast::new(&format!("Restore failed: {}", e));
+                t.add_toast(toast);
+            }
+        }
+    });
+
+    let path_diff = path.clone();
+    let restore_container_c = restore_container.clone();
+    let stack_diff = stack.clone();
+    let model_diff = model.clone();
+    let toast_diff = toast_overlay.clone();
+
+    diff_btn.connect_clicked(move |_| {
+        while let Some(child) = restore_container_c.first_child() {
+            restore_container_c.remove(&child);
+        }
+        let diff_view = create_diff_view(
+            &path_diff,
+            &stack_diff,
+            &model_diff,
+            &toast_diff,
+            &restore_container_c,
+        );
+        restore_container_c.append(&diff_view);
+    });
+
+    row.upcast()
+}
+
+fn create_diff_view(
+    path: &std::path::PathBuf,
+    stack: &gtk::Stack,
+    model: &gtk::gio::ListStore,
+    toast_overlay: &adw::ToastOverlay,
+    restore_container: &gtk::Box,
+) -> gtk::Widget {
+    let container = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(12)
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .vexpand(true)
+        .build();
+
+    let outer_scroll = gtk::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vexpand(true)
+        .child(&container)
+        .build();
+
+    let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+    let back_btn = gtk::Button::builder()
+        .icon_name("go-previous-symbolic")
+        .css_classes(["flat", "circular"])
+        .build();
+
+    let restore_container_c = restore_container.clone();
+    let stack_c = stack.clone();
+    let model_c = model.clone();
+    let toast_c = toast_overlay.clone();
+    back_btn.connect_clicked(move |_| {
+        while let Some(child) = restore_container_c.first_child() {
+            restore_container_c.remove(&child);
+        }
+        let restore_view = create_restore_view(&stack_c, &model_c, &toast_c, &restore_container_c);
+        restore_container_c.append(&restore_view);
+    });
+
+    let timestamp = path
+        .file_name()
+        .map(|n| n.to_string_lossy())
+        .unwrap_or_default();
+    let title = gtk::Label::builder()
+        .label(&format!("Diff: {}", timestamp))
+        .css_classes(["title-2"])
+        .halign(gtk::Align::Start)
+        .build();
+
+    header.append(&back_btn);
+    header.append(&title);
+    container.append(&header);
+
+    let scroll = gtk::ScrolledWindow::builder().vexpand(true).build();
+
+    let text_view = gtk::TextView::builder()
+        .editable(false)
+        .cursor_visible(false)
+        .monospace(true)
+        .wrap_mode(gtk::WrapMode::Char)
+        .build();
+
+    let buffer = text_view.buffer();
+    let tag_table = buffer.tag_table();
+
+    let tag_add = gtk::TextTag::builder()
+        .name("add")
+        .foreground("#26a269")
+        .build();
+    let tag_del = gtk::TextTag::builder()
+        .name("del")
+        .foreground("#c01c28")
+        .build();
+    let tag_header = gtk::TextTag::builder()
+        .name("header")
+        .foreground("#1c71d8")
+        .weight(gtk::pango::Weight::Bold.into_glib())
+        .build();
+
+    tag_table.add(&tag_add);
+    tag_table.add(&tag_del);
+    tag_table.add(&tag_header);
+
+    match generate_diff(path) {
+        Ok(diff_text) => {
+            let mut iter = buffer.start_iter();
+            for line in diff_text.lines() {
+                let tag_name = if line.starts_with('+') && !line.starts_with("+++") {
+                    Some("add")
+                } else if line.starts_with('-') && !line.starts_with("---") {
+                    Some("del")
+                } else if line.starts_with("---") || line.starts_with("+++") {
+                    Some("header")
+                } else {
+                    None
+                };
+
+                let line_with_newline = format!("{}\n", line);
+                if let Some(tag) = tag_name {
+                    buffer.insert_with_tags_by_name(&mut iter, &line_with_newline, &[tag]);
+                } else {
+                    buffer.insert(&mut iter, &line_with_newline);
+                }
+            }
+        }
+        Err(e) => {
+            buffer.set_text(&format!("Error generating diff: {}", e));
+        }
+    }
+
+    scroll.set_child(Some(&text_view));
+    container.append(&scroll);
+
+    outer_scroll.upcast()
+}

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -369,6 +369,9 @@ pub fn build_ui(app: &adw::Application) {
     let wizard_page_container = gtk::Box::new(gtk::Orientation::Vertical, 0);
     root_stack.add_named(&wizard_page_container, Some("wizard"));
 
+    let restore_page_container = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    root_stack.add_named(&restore_page_container, Some("restore"));
+
     let settings_page_container = gtk::Box::new(gtk::Orientation::Vertical, 0);
     root_stack.add_named(&settings_page_container, Some("settings"));
 
@@ -723,6 +726,7 @@ pub fn build_ui(app: &adw::Application) {
     let column_view_clone = column_view.clone();
     let model_settings = model.clone();
     let toast_overlay_settings = toast_overlay.clone();
+    let restore_container_settings = restore_page_container.clone();
 
     settings_button.connect_clicked(move |_| {
         while let Some(child) = container_settings.first_child() {
@@ -740,7 +744,13 @@ pub fn build_ui(app: &adw::Application) {
         let col_submap_sort_c = col_submap_clone.clone();
         let col_view_c = column_view_clone.clone();
         let model_s = model_settings.clone();
+        let model_s_restore = model_settings.clone();
         let toast_s = toast_overlay_settings.clone();
+        let stack_s = stack_settings.clone();
+        let restore_container_s = restore_container_settings.clone();
+
+        let toast_s_1 = toast_s.clone();
+        let toast_s_2 = toast_s.clone();
 
         let view = crate::ui::settings::create_settings_view(
             &window_settings,
@@ -764,7 +774,20 @@ pub fn build_ui(app: &adw::Application) {
             }),
             std::rc::Rc::new(move |msg| {
                 let toast = adw::Toast::new(&msg);
-                toast_s.add_toast(toast);
+                toast_s_1.add_toast(toast);
+            }),
+            std::rc::Rc::new(move || {
+                while let Some(child) = restore_container_s.first_child() {
+                    restore_container_s.remove(&child);
+                }
+                let restore_view = crate::ui::views::create_restore_view(
+                    &stack_s,
+                    &model_s_restore,
+                    &toast_s_2,
+                    &restore_container_s,
+                );
+                restore_container_s.append(&restore_view);
+                stack_s.set_visible_child_name("restore");
             }),
         );
         container_settings.append(&view);


### PR DESCRIPTION
**Backup and Restore Functionality:**

* Added recursive backup of the entire `~/.config/hypr` directory, preserving folder structures and external scripts, with improved error handling and reporting. [[1]](diffhunk://#diff-a1ef3c03187f374619be174e9e5ca29990dc70248adafa910b2b6a3cf48802a2L17-R90) [[2]](diffhunk://#diff-a1ef3c03187f374619be174e9e5ca29990dc70248adafa910b2b6a3cf48802a2R102-R275)
* Introduced a restore feature to recover the full configuration tree from any backup, including error reporting for partial restores.
* Implemented a function to generate Git-style visual diffs between current configuration and backups, highlighting additions and removals.
* Added a utility to list all available backups, sorted by date.
* Exposed the new backup utilities (`restore_backup`, `generate_diff`, `list_backups`) for use in the application.