### PR TITLE
1.18.6: broken bind detection enhancement

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = hyprkcs-git
 	pkgdesc = A fast, minimal Hyprland keybind cheat sheet and editor written in Rust/GTK4
-	pkgver = 1.18.5
+	pkgver = 1.18.6
 	pkgrel = 1
 	url = https://github.com/kosa12/hyprKCS
 	arch = x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyprKCS"
-version = "1.18.5"
+version = "1.18.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "hyprKCS"
-version = "1.18.5"
+version = "1.18.6"
 edition = "2021"
 license = "MIT"
 description = "A fast, lightweight, and graphical keybind manager for Hyprland"
 repository = "https://github.com/kosa12/hyprKCS"
 homepage = "https://github.com/kosa12/hyprKCS"
 readme = "README.md"
-keywords = ["hyprland", "keybinds", "manager", "gui", "gtk4"]
-categories = ["gui", "os::linux-apis"]
+keywords = ["hyprland", "keybinds", "manager", "gui", "gtk4", "linux", "wayland"]
+categories = ["gui", "os::linux-apis", "accessibility", "config"]
 exclude = [
     "assets/*",
     "mine/*",

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kosa Matyas <kosa03matyas@gmail.com>
 pkgname=hyprkcs-git
-pkgver=1.18.5
+pkgver=1.18.6
 pkgrel=1
 pkgdesc="A fast, minimal Hyprland keybind cheat sheet and editor written in Rust/GTK4"
 arch=('x86_64')

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ hyprKCS provides a simple and intuitive interface to view, edit, and manage your
 - **Visual Keyboard Map**: Interactive layout to visualize used and available keys for any modifier combination. Supports multiple physical layouts including ANSI, ISO, JIS, ABNT2, or Hungarian.
 - **Category Filtering**: Filter binds by common categories like Workspace, Window, Media, or Custom scripts.
 - **Conflict Detection**: Automatically identifies and highlights duplicate keybinds, resolving Hyprland variables (e.g., `$mainMod`) for accuracy.
+- **Broken Bind Detection**: Automatically validates `exec` and `execr` commands, flagging keybinds that point to missing executables or scripts with a red exclamation mark.
 - **Full Keybind Management**: Add, edit, and delete keybinds directly from the UI. Changes are written back to the correct configuration files.
 - **Configuration Backup**: Create a timestamped backup of your configuration files with a single click or set the automatic backup behavior in the settings (it's set to true by default).
 - **Interactive Restore**: Easily browse previous backups and restore your entire configuration tree with a single click.

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "hyprkcs";
-            version = "1.18.5";
+            version = "1.18.6";
 
             src = let
               fs = pkgs.lib.fileset;

--- a/src/keybind_object.rs
+++ b/src/keybind_object.rs
@@ -11,7 +11,12 @@ glib::wrapper! {
 }
 
 impl KeybindObject {
-    pub fn new(keybind: Keybind, conflict_reason: Option<String>, is_favorite: bool) -> Self {
+    pub fn new(
+        keybind: Keybind,
+        conflict_reason: Option<String>,
+        broken_reason: Option<String>,
+        is_favorite: bool,
+    ) -> Self {
         let obj: Self = glib::Object::new();
 
         {
@@ -54,6 +59,14 @@ impl KeybindObject {
             } else {
                 data.is_conflicted = false;
                 data.conflict_reason = "".into();
+            }
+
+            if let Some(reason) = broken_reason {
+                data.is_broken = true;
+                data.broken_reason = reason.into();
+            } else {
+                data.is_broken = false;
+                data.broken_reason = "".into();
             }
         }
 
@@ -186,6 +199,8 @@ pub mod imp {
         pub is_conflicted: bool,
         pub conflict_reason: Rc<str>,
         pub is_favorite: bool,
+        pub is_broken: bool,
+        pub broken_reason: Rc<str>,
 
         // Cached lowercase fields for search optimization
         pub mods_lower: Rc<str>,
@@ -223,6 +238,8 @@ pub mod imp {
                     glib::ParamSpecBoolean::builder("is-conflicted").build(),
                     glib::ParamSpecString::builder("conflict-reason").build(),
                     glib::ParamSpecBoolean::builder("is-favorite").build(),
+                    glib::ParamSpecBoolean::builder("is-broken").build(),
+                    glib::ParamSpecString::builder("broken-reason").build(),
                 ]
             });
             PROPERTIES.as_ref()
@@ -286,6 +303,11 @@ pub mod imp {
                     data.conflict_reason = v.into();
                 }
                 "is-favorite" => data.is_favorite = value.get().unwrap(),
+                "is-broken" => data.is_broken = value.get().unwrap(),
+                "broken-reason" => {
+                    let v: String = value.get().unwrap();
+                    data.broken_reason = v.into();
+                }
                 _ => unimplemented!(),
             }
         }
@@ -305,6 +327,8 @@ pub mod imp {
                 "is-conflicted" => data.is_conflicted.to_value(),
                 "conflict-reason" => data.conflict_reason.as_ref().to_value(),
                 "is-favorite" => data.is_favorite.to_value(),
+                "is-broken" => data.is_broken.to_value(),
+                "broken-reason" => data.broken_reason.as_ref().to_value(),
                 _ => unimplemented!(),
             }
         }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -125,8 +125,8 @@ fn generate_css(config: &StyleConfig) -> String {
             font-size: {font_size};
         }}
 
-        /* Conflict Styling */
-        .error-icon {{
+        /* Conflict & Broken Styling */
+        .error-icon, .destructive-action {{
             color: @error_color;
         }}
 


### PR DESCRIPTION
**Keybind Validation and UI Enhancements:**

* Added automatic detection of broken keybinds by validating `exec` and `execr` commands; keybinds with missing executables/scripts are now flagged and annotated with a reason. [[1]](diffhunk://#diff-6879e406a51b53633af56e65fa0b3a214f46961cfd5e2173bec28474d829de22R66-R84) [[2]](diffhunk://#diff-6879e406a51b53633af56e65fa0b3a214f46961cfd5e2173bec28474d829de22R94-R101) [[3]](diffhunk://#diff-6879e406a51b53633af56e65fa0b3a214f46961cfd5e2173bec28474d829de22L85-R110) [[4]](diffhunk://#diff-ba4655f9073e0d28110a93c9bef0934250d87b74d8c166086bad96de55b1f4b0L58-R87) [[5]](diffhunk://#diff-ba4655f9073e0d28110a93c9bef0934250d87b74d8c166086bad96de55b1f4b0L77-R113) [[6]](diffhunk://#diff-12874756eecf0e989b85bb7260159405848047cfc54ba2f13da7257d9aab976cL14-R19) [[7]](diffhunk://#diff-12874756eecf0e989b85bb7260159405848047cfc54ba2f13da7257d9aab976cR63-R70) [[8]](diffhunk://#diff-12874756eecf0e989b85bb7260159405848047cfc54ba2f13da7257d9aab976cR202-R203)
* Updated the UI to display a red error icon for broken keybinds, with tooltips showing the reason, and adjusted CSS styling to support this new indicator. [[1]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577R153-R170) [[2]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L172-R200) [[3]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577R225-R229) [[4]](diffhunk://#diff-98f5d75e3ef1c7cb38c1d557e9b883919bbd303c95acb623de2441f08abef0dbL128-R129) [[5]](diffhunk://#diff-12874756eecf0e989b85bb7260159405848047cfc54ba2f13da7257d9aab976cR241-R242) [[6]](diffhunk://#diff-12874756eecf0e989b85bb7260159405848047cfc54ba2f13da7257d9aab976cR306-R310) [[7]](diffhunk://#diff-12874756eecf0e989b85bb7260159405848047cfc54ba2f13da7257d9aab976cR330-R331)