### PR TITLE
1.23.2: feat: clone whole keybind

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = hyprkcs-git
 	pkgdesc = A fast, minimal Hyprland keybind cheat sheet and editor written in Rust/GTK4
-	pkgver = 1.23.1
+	pkgver = 1.23.2
 	pkgrel = 1
 	url = https://github.com/kosa12/hyprKCS
 	arch = x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyprKCS"
-version = "1.23.1"
+version = "1.23.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprKCS"
-version = "1.23.1"
+version = "1.23.2"
 edition = "2021"
 license = "GPL-3.0"
 description = "A fast, lightweight, and graphical keybind manager for Hyprland"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kosa Matyas <kosa03matyas@gmail.com>
 pkgname=hyprkcs-git
-pkgver=1.23.1
+pkgver=1.23.2
 pkgrel=1
 pkgdesc="A fast, minimal Hyprland keybind cheat sheet and editor written in Rust/GTK4"
 arch=('x86_64')

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "hyprkcs";
-            version = "1.23.1";
+            version = "1.23.2";
 
             src = let
               fs = pkgs.lib.fileset;

--- a/src/ui/utils/clone.rs
+++ b/src/ui/utils/clone.rs
@@ -1,0 +1,152 @@
+use crate::parser;
+use crate::ui::utils::components::{get_flag_from_index, get_mouse_code_from_index};
+use crate::ui::utils::macro_builder::compile_macro;
+use crate::ui::utils::{create_pill_button, reload_keybinds};
+use gtk::{gio, prelude::*};
+use gtk4 as gtk;
+use libadwaita as adw;
+use std::path::PathBuf;
+
+#[allow(deprecated)]
+pub struct CloneContext {
+    pub file_path: PathBuf,
+    pub model: gio::ListStore,
+    pub toast_overlay: adw::ToastOverlay,
+    pub stack: gtk::Stack,
+
+    pub entry_mods: gtk::Entry,
+    pub entry_key: gtk::Entry,
+    pub entry_dispatcher: gtk::Entry,
+    pub entry_args: gtk::Entry,
+    pub entry_desc: gtk::Entry,
+    pub entry_submap: gtk::ComboBoxText,
+
+    pub macro_switch: gtk::Switch,
+    pub macro_list: gtk::Box,
+    pub flags_dropdown: gtk::DropDown,
+    pub mouse_switch: gtk::Switch,
+    pub mouse_dropdown: gtk::DropDown,
+
+    pub mods_had_prefix: bool,
+    pub args_had_prefix: bool,
+}
+
+pub fn create_clone_button(ctx: CloneContext) -> gtk::Button {
+    let btn = create_pill_button("Clone", Some("edit-copy-symbolic"));
+    btn.set_tooltip_text(Some("Save as a new keybind"));
+
+    // We need to move the context into the closure.
+    // Since we can't move fields out of the struct easily without destructuring,
+    // we'll clone what we need. Since GTK widgets are ref-counted (internally), cloning them is cheap.
+
+    let file_path = ctx.file_path.clone();
+    let model = ctx.model.clone();
+    let toast_overlay = ctx.toast_overlay.clone();
+    let stack = ctx.stack.clone();
+    let entry_mods = ctx.entry_mods.clone();
+    let entry_key = ctx.entry_key.clone();
+    let entry_dispatcher = ctx.entry_dispatcher.clone();
+    let entry_args = ctx.entry_args.clone();
+    let entry_desc = ctx.entry_desc.clone();
+    let entry_submap = ctx.entry_submap.clone();
+    let macro_switch = ctx.macro_switch.clone();
+    let macro_list = ctx.macro_list.clone();
+    let flags_dropdown = ctx.flags_dropdown.clone();
+    let mouse_switch = ctx.mouse_switch.clone();
+    let mouse_dropdown = ctx.mouse_dropdown.clone();
+    let mods_had_prefix = ctx.mods_had_prefix;
+    let args_had_prefix = ctx.args_had_prefix;
+
+    btn.connect_clicked(move |_| {
+        let input_mods = entry_mods.text().to_string();
+        let new_mods = if mods_had_prefix {
+            format!("${}", input_mods)
+        } else {
+            input_mods
+        };
+
+        let new_key = if mouse_switch.is_active() {
+            get_mouse_code_from_index(mouse_dropdown.selected()).to_string()
+        } else {
+            entry_key.text().to_string()
+        };
+
+        let desc = entry_desc.text().to_string();
+        let new_flag = get_flag_from_index(flags_dropdown.selected());
+
+        #[allow(deprecated)]
+        let submap_id = entry_submap.active_id();
+        let new_submap = if let Some(id) = submap_id {
+            if id.is_empty() {
+                None
+            } else {
+                Some(id.to_string())
+            }
+        } else {
+            #[allow(deprecated)]
+            if let Some(text) = entry_submap.active_text() {
+                let t = text.as_str().trim();
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t.to_string())
+                }
+            } else {
+                None
+            }
+        };
+
+        let (new_dispatcher, new_args) = if macro_switch.is_active() {
+            match compile_macro(&macro_list) {
+                Some(res) => res,
+                None => {
+                    let toast = adw::Toast::builder()
+                        .title("Macro is empty or invalid")
+                        .timeout(crate::config::constants::TOAST_TIMEOUT)
+                        .build();
+                    toast_overlay.add_toast(toast);
+                    return;
+                }
+            }
+        } else {
+            let d = entry_dispatcher.text().to_string();
+            let input_args = entry_args.text().to_string();
+            let a = if args_had_prefix {
+                format!("${}", input_args)
+            } else {
+                input_args
+            };
+            (d, a)
+        };
+
+        match parser::add_keybind(
+            file_path.clone(),
+            &new_mods,
+            &new_key,
+            &new_dispatcher,
+            &new_args,
+            new_submap,
+            if desc.is_empty() { None } else { Some(desc) },
+            new_flag,
+        ) {
+            Ok(_) => {
+                reload_keybinds(&model);
+                let toast = adw::Toast::builder()
+                    .title("Keybind cloned successfully")
+                    .timeout(crate::config::constants::TOAST_TIMEOUT)
+                    .build();
+                toast_overlay.add_toast(toast);
+                stack.set_visible_child_name("home");
+            }
+            Err(e) => {
+                let toast = adw::Toast::builder()
+                    .title(format!("Error cloning: {}", e))
+                    .timeout(crate::config::constants::TOAST_TIMEOUT)
+                    .build();
+                toast_overlay.add_toast(toast);
+            }
+        }
+    });
+
+    btn
+}

--- a/src/ui/utils/mod.rs
+++ b/src/ui/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod backup;
+pub mod clone;
 pub mod components;
 pub mod conflicts;
 pub mod execution;

--- a/src/ui/views/edit.rs
+++ b/src/ui/views/edit.rs
@@ -1,5 +1,6 @@
 use crate::keybind_object::KeybindObject;
 use crate::parser;
+use crate::ui::utils::clone::{create_clone_button, CloneContext};
 use crate::ui::utils::components::{
     create_flags_dropdown, create_mouse_button_dropdown, create_recorder_row, get_flag_from_index,
     get_index_from_flag, get_index_from_mouse_code, get_mouse_code_from_index,
@@ -276,11 +277,30 @@ pub fn create_edit_view(
     let button_box = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
         .spacing(12)
-        .halign(gtk::Align::End)
         .margin_top(12)
         .build();
 
     let delete_btn = create_destructive_button("Delete", None);
+    let clone_ctx = CloneContext {
+        file_path: PathBuf::from(&file_path_display),
+        model: model.clone(),
+        toast_overlay: toast_overlay.clone(),
+        stack: stack.clone(),
+        entry_mods: entry_mods.clone(),
+        entry_key: entry_key.clone(),
+        entry_dispatcher: entry_dispatcher.clone(),
+        entry_args: entry_args.clone(),
+        entry_desc: entry_desc.clone(),
+        entry_submap: entry_submap.clone(),
+        macro_switch: macro_switch.clone(),
+        macro_list: macro_list.clone(),
+        flags_dropdown: flags_dropdown.clone(),
+        mouse_switch: mouse_switch.clone(),
+        mouse_dropdown: mouse_dropdown.clone(),
+        mods_had_prefix,
+        args_had_prefix,
+    };
+    let clone_btn = create_clone_button(clone_ctx);
     let exec_btn = create_pill_button("Execute", None);
     exec_btn.set_tooltip_text(Some("Test this keybind immediately using hyprctl dispatch"));
     let cancel_btn = create_pill_button("Cancel", None);
@@ -289,6 +309,7 @@ pub fn create_edit_view(
     button_box.append(&delete_btn);
     let spacer = gtk::Box::builder().hexpand(true).build();
     button_box.append(&spacer);
+    button_box.append(&clone_btn);
     button_box.append(&exec_btn);
     button_box.append(&cancel_btn);
     button_box.append(&save_btn);


### PR DESCRIPTION
### New keybind cloning feature

* Added a new `CloneContext` struct and `create_clone_button` function in `src/ui/utils/clone.rs` to encapsulate the logic for duplicating keybinds, including gathering form data, handling macro compilation, and updating the UI with feedback.
* Integrated the clone button into the keybind edit view in `src/ui/views/edit.rs`, enabling users to clone keybinds directly from the edit interface. [[1]](diffhunk://#diff-ad693707154e199c91f4be6df28c51abb5772450618466713bb80e26aef68e8cR3) [[2]](diffhunk://#diff-ad693707154e199c91f4be6df28c51abb5772450618466713bb80e26aef68e8cL279-R303) [[3]](diffhunk://#diff-ad693707154e199c91f4be6df28c51abb5772450618466713bb80e26aef68e8cR312)
* Registered the new `clone` utility module in `src/ui/utils/mod.rs` for better code organization.