### PR TITLE
fix: Omarchy colors.toml path

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Click the keyboard icon in the top toolbar to open an interactive keyboard layou
 For users of **Omarchy**, hyprKCS offers native color synchronization.
 1. Navigate to **Settings > Appearance**.
 2. Change the **Theme** dropdown to **Omarchy**.
-3. hyprKCS will automatically look for your `colors.toml` (in `~/.config/omarchy/` or `~/.config/hypr/`) and apply your system's background, foreground, and accent colors to the interface.
+3. hyprKCS will automatically look for your `colors.toml` (in `~/.config/omarchy/current/theme/` or `~/.config/hypr/`) and apply your system's background, foreground, and accent colors to the interface.
 4. If you haven't set up a `colors.toml` yet, the app will notify you and revert to the default Adwaita theme.
 
 <p align="center">

--- a/src/ui/settings/appearance.rs
+++ b/src/ui/settings/appearance.rs
@@ -47,7 +47,7 @@ pub fn create_appearance_page(
             let mut found = false;
             if let Some(config_dir) = dirs::config_dir() {
                 let paths = [
-                    config_dir.join("omarchy/colors.toml"),
+                    config_dir.join("omarchy/current/theme/colors.toml"),
                     config_dir.join("hypr/colors.toml"),
                 ];
                 for path in &paths {
@@ -59,7 +59,7 @@ pub fn create_appearance_page(
             }
             if !found {
                 toast(
-                    "Omarchy colors.toml not found in ~/.config/omarchy/ or ~/.config/hypr/"
+                    "Omarchy colors.toml not found in ~/.config/omarchy/current/theme/ or ~/.config/hypr/"
                         .to_string(),
                 );
                 d.set_selected(0);

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -14,7 +14,7 @@ fn parse_omarchy_colors() -> Option<std::collections::HashMap<String, String>> {
     if let Some(config_dir) = dirs::config_dir() {
         // Check both locations as fallback
         let paths = [
-            config_dir.join("omarchy/colors.toml"),
+            config_dir.join("omarchy/current/theme/colors.toml"),
             config_dir.join("hypr/colors.toml"),
         ];
 


### PR DESCRIPTION
isn't it the default path?
```
~ ❯ fd colors.toml .config/omarchy/
.config/omarchy/current/theme/colors.toml

~ ❯ ls .config/omarchy/
Permissions Size User       Date Modified Name
drwxr-xr-x     - krisavdome  4 Feb 01:43   backgrounds
drwxr-xr-x     - krisavdome 10 Nov  2025   branding
drwxr-xr-x     - krisavdome 21 Feb 17:09   current
drwxr-xr-x     - krisavdome  1 Feb 17:54   extensions
drwxr-xr-x     - krisavdome 21 Feb 20:45   hooks
drwxr-xr-x     - krisavdome  1 Feb 17:54   themed
drwxr-xr-x     - krisavdome 15 Jan 19:21   themes
```