### PR TITLE
1.25.4: feat: HUD customization

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = hyprkcs-git
 	pkgdesc = A fast, minimal Hyprland keybind cheat sheet and editor written in Rust/GTK4
-	pkgver = 1.25.3
+	pkgver = 1.25.4
 	pkgrel = 1
 	url = https://github.com/kosa12/hyprKCS
 	arch = x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyprKCS"
-version = "1.25.3"
+version = "1.25.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprKCS"
-version = "1.25.3"
+version = "1.25.4"
 edition = "2021"
 license = "GPL-3.0"
 description = "A fast, lightweight, and graphical keybind manager for Hyprland"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kosa Matyas <kosa03matyas@gmail.com>
 pkgname=hyprkcs-git
-pkgver=1.25.3
+pkgver=1.25.4
 pkgrel=1
 pkgdesc="A fast, minimal Hyprland keybind cheat sheet and editor written in Rust/GTK4"
 arch=('x86_64')

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "hyprkcs";
-            version = "1.25.3";
+            version = "1.25.4";
 
             src = let
               fs = pkgs.lib.fileset;

--- a/src/config/hud.rs
+++ b/src/config/hud.rs
@@ -58,11 +58,27 @@ impl HudPosition {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct HudConfig {
     pub enabled: bool,
     pub position: HudPosition,
     pub keybinds: Vec<HudKeybind>,
+    pub opacity: f64,
+    pub border_radius: i32,
+    pub font_size: i32,
+}
+
+impl Default for HudConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            position: HudPosition::TopRight,
+            keybinds: Vec::new(),
+            opacity: 0.8,
+            border_radius: 12,
+            font_size: 14,
+        }
+    }
 }
 
 static HUD_CONFIG_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
@@ -88,11 +104,7 @@ pub fn load_hud_config() -> HudConfig {
         return HudConfig::default();
     };
 
-    let mut config = HudConfig {
-        enabled: false,
-        position: HudPosition::TopRight,
-        keybinds: Vec::with_capacity(8), // Pre-allocate for typical use
-    };
+    let mut config = HudConfig::default();
 
     for line in content.lines() {
         let line = line.trim();
@@ -104,6 +116,12 @@ pub fn load_hud_config() -> HudConfig {
             config.enabled = value == "true";
         } else if let Some(value) = line.strip_prefix("position=") {
             config.position = HudPosition::from_str(value).unwrap_or_default();
+        } else if let Some(value) = line.strip_prefix("opacity=") {
+            config.opacity = value.parse().unwrap_or(0.8);
+        } else if let Some(value) = line.strip_prefix("border_radius=") {
+            config.border_radius = value.parse().unwrap_or(12);
+        } else if let Some(value) = line.strip_prefix("font_size=") {
+            config.font_size = value.parse().unwrap_or(14);
         } else if line.contains('|') {
             let mut parts = line.splitn(4, '|');
             if let (Some(mods), Some(key), Some(disp), Some(args)) =
@@ -141,6 +159,15 @@ pub fn save_hud_config(config: &HudConfig) -> std::io::Result<()> {
     content.push('\n');
     content.push_str("position=");
     content.push_str(config.position.as_str());
+    content.push('\n');
+    content.push_str("opacity=");
+    content.push_str(&config.opacity.to_string());
+    content.push('\n');
+    content.push_str("border_radius=");
+    content.push_str(&config.border_radius.to_string());
+    content.push('\n');
+    content.push_str("font_size=");
+    content.push_str(&config.font_size.to_string());
     content.push('\n');
 
     for k in &config.keybinds {

--- a/src/ui/hud.rs
+++ b/src/ui/hud.rs
@@ -1,5 +1,4 @@
 use crate::config::hud::{get_hud_pid_path, is_hud_running, load_hud_config, HudPosition};
-use crate::config::StyleConfig;
 use gtk::gio;
 use gtk::glib;
 use gtk::prelude::*;
@@ -37,90 +36,50 @@ fn update_window_position(window: &gtk::ApplicationWindow, position: HudPosition
     }
 }
 
-fn generate_hud_css(style: &StyleConfig) -> String {
-    let border_radius = style.border_radius.as_deref().unwrap_or("16px");
-
-    let font_size = style.font_size.as_deref().unwrap_or("0.9rem");
-
-    let opacity = style.opacity.unwrap_or(0.75);
+fn generate_hud_css(hud_config: &crate::config::hud::HudConfig) -> String {
+    let border_radius = format!("{}px", hud_config.border_radius);
+    let font_size = format!("{}px", hud_config.font_size);
+    let opacity = hud_config.opacity;
 
     format!(
         r#"
-
         window, .background, .main {{
-
             background-color: transparent;
-
             background-image: none;
-
             box-shadow: none;
-
         }}
-
         .hud-container {{
-
             background: alpha(@window_bg_color, {});
-
             padding: 24px;
-
             border-radius: {};
-
             border: 1px solid alpha(@window_fg_color, 0.1);
-
             color: @window_fg_color;
-
         }}
-
         .hud-title {{
-
             font-size: calc({} * 1.3);
-
             font-weight: 800;
-
             margin-bottom: 4px;
-
             color: @window_fg_color;
-
         }}
-
         .hud-keys {{
-
             font-size: {};
-
             font-weight: 600;
-
             color: @accent_color;
-
             font-family: monospace;
-
         }}
-
         .hud-action {{
-
             font-size: {};
-
             color: alpha(@window_fg_color, 0.8);
-
             font-style: italic;
-
         }}
-
         .hud-empty {{
-
             color: alpha(@window_fg_color, 0.4);
-
             padding: 10px;
-
         }}
-
         separator {{
-
             background-color: alpha(@window_fg_color, 0.1);
-
             margin-bottom: 8px;
-
         }}
-
     "#,
         opacity, border_radius, font_size, font_size, font_size
     )
@@ -235,9 +194,7 @@ pub fn run_hud() {
 
         let theme_provider = gtk::CssProvider::new();
 
-        let style = StyleConfig::load();
-
-        app_provider.load_from_string(&generate_hud_css(&style));
+        app_provider.load_from_string(&generate_hud_css(&config));
 
         if let Some(config_dir) = dirs::config_dir() {
             let gtk_css_path = config_dir.join("gtk-4.0/gtk.css");
@@ -318,8 +275,8 @@ pub fn run_hud() {
                 }
             }
 
-            let style = StyleConfig::load();
-            app_prov_c.load_from_string(&generate_hud_css(&style));
+            let hud_cfg = load_hud_config();
+            app_prov_c.load_from_string(&generate_hud_css(&hud_cfg));
         };
 
         let reload = reload_all.clone();
@@ -389,8 +346,10 @@ pub fn run_hud() {
                                                     } else {
                                                         tp.load_from_string("");
                                                     }
-                                                    let style = StyleConfig::load();
-                                                    ap.load_from_string(&generate_hud_css(&style));
+                                                    let hud_cfg = load_hud_config();
+                                                    ap.load_from_string(&generate_hud_css(
+                                                        &hud_cfg,
+                                                    ));
                                                     glib::ControlFlow::Break
                                                 },
                                             );
@@ -421,9 +380,9 @@ pub fn run_hud() {
                 let app_prov_f2 = app_prov_f.clone();
 
                 monitor.connect_changed(move |_, _, _, _| {
-                    let style = StyleConfig::load();
+                    let hud_cfg = load_hud_config();
 
-                    app_prov_f2.load_from_string(&generate_hud_css(&style));
+                    app_prov_f2.load_from_string(&generate_hud_css(&hud_cfg));
                 });
 
                 unsafe {
@@ -439,6 +398,7 @@ pub fn run_hud() {
                 file_hud.monitor(gio::FileMonitorFlags::NONE, gio::Cancellable::NONE)
             {
                 let window_p = window.clone();
+                let app_prov_f3 = app_provider.clone();
 
                 monitor.connect_changed(move |_, _, _, _| {
                     let cfg = load_hud_config();
@@ -446,6 +406,7 @@ pub fn run_hud() {
                     update_keybind_list(&container_f);
 
                     update_window_position(&window_p, cfg.position);
+                    app_prov_f3.load_from_string(&generate_hud_css(&cfg));
                 });
 
                 unsafe {

--- a/src/ui/settings/hud.rs
+++ b/src/ui/settings/hud.rs
@@ -134,6 +134,117 @@ pub fn create_hud_page(model: &gio::ListStore, on_show_toast: Rc<dyn Fn(String)>
     main_box.append(&header_box);
     main_box.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
 
+    // --- Styling Section (Compact) ---
+    let styling_clamp = adw::Clamp::builder().maximum_size(800).build();
+    let styling_group = adw::PreferencesGroup::builder()
+        .margin_start(12)
+        .margin_end(12)
+        .margin_top(6)
+        .build();
+
+    let expander = adw::ExpanderRow::builder()
+        .title("HUD Appearance")
+        .subtitle("Customize opacity, corners, and font size")
+        .expanded(false)
+        .build();
+
+    // Opacity
+    let opacity_adj = gtk::Adjustment::new(config.borrow().opacity, 0.0, 1.0, 0.05, 0.1, 0.0);
+    let opacity_scale = gtk::Scale::builder()
+        .adjustment(&opacity_adj)
+        .digits(2)
+        .hexpand(true)
+        .valign(gtk::Align::Center)
+        .width_request(120)
+        .build();
+
+    let opacity_label = gtk::Label::builder()
+        .label(&format!("{}%", (config.borrow().opacity * 100.0) as i32))
+        .valign(gtk::Align::Center)
+        .css_classes(["caption", "dim-label"])
+        .width_request(40)
+        .build();
+
+    let opacity_box = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(8)
+        .build();
+    opacity_box.append(&opacity_scale);
+    opacity_box.append(&opacity_label);
+
+    let opacity_row = adw::ActionRow::builder().title("Opacity").build();
+    opacity_row.add_suffix(&opacity_box);
+
+    let config_opacity_ref = Rc::clone(&config);
+    let opacity_label_c = opacity_label.clone();
+    opacity_scale.connect_value_changed(move |s| {
+        let mut cfg = config_opacity_ref.borrow_mut();
+        cfg.opacity = s.value();
+        opacity_label_c.set_label(&format!("{}%", (s.value() * 100.0) as i32));
+        let _ = save_hud_config(&cfg);
+    });
+
+    // Border Radius
+    let radius_adj = gtk::Adjustment::new(
+        config.borrow().border_radius as f64,
+        0.0,
+        50.0,
+        1.0,
+        5.0,
+        0.0,
+    );
+    let radius_spin = gtk::SpinButton::builder()
+        .adjustment(&radius_adj)
+        .valign(gtk::Align::Center)
+        .build();
+
+    let radius_row = adw::ActionRow::builder()
+        .title("Border Radius (px)")
+        .build();
+    radius_row.add_suffix(&radius_spin);
+
+    let config_radius_ref = Rc::clone(&config);
+    radius_spin.connect_value_changed(move |s| {
+        let mut cfg = config_radius_ref.borrow_mut();
+        cfg.border_radius = s.value() as i32;
+        let _ = save_hud_config(&cfg);
+    });
+
+    // Font Size
+    let font_adj = gtk::Adjustment::new(config.borrow().font_size as f64, 8.0, 48.0, 1.0, 4.0, 0.0);
+    let font_spin = gtk::SpinButton::builder()
+        .adjustment(&font_adj)
+        .valign(gtk::Align::Center)
+        .build();
+
+    let font_row = adw::ActionRow::builder().title("Font Size (px)").build();
+    font_row.add_suffix(&font_spin);
+
+    let config_font_ref = Rc::clone(&config);
+    font_spin.connect_value_changed(move |s| {
+        let mut cfg = config_font_ref.borrow_mut();
+        cfg.font_size = s.value() as i32;
+        let _ = save_hud_config(&cfg);
+    });
+
+    expander.add_row(&opacity_row);
+    expander.add_row(&radius_row);
+    expander.add_row(&font_row);
+
+    styling_group.add(&expander);
+    styling_clamp.set_child(Some(&styling_group));
+    main_box.append(&styling_clamp);
+
+    let keybinds_label = gtk::Label::builder()
+        .label("Keybind Selection")
+        .halign(gtk::Align::Start)
+        .margin_start(24)
+        .margin_top(6)
+        .margin_bottom(6)
+        .css_classes(["heading"])
+        .build();
+    main_box.append(&keybinds_label);
+
     // --- List Content ---
     let scrolled = gtk::ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Never)


### PR DESCRIPTION
**HUD Appearance Customization:**

* Added new fields (`opacity`, `border_radius`, `font_size`) to the `HudConfig` struct, with appropriate defaults and serialization/deserialization in the config loader and saver (`src/config/hud.rs`). [[1]](diffhunk://#diff-eb017d9680d95f37e93ed85a2ab31245fc1d0b031740633ea5978d03714ddd9bL61-R81) [[2]](diffhunk://#diff-eb017d9680d95f37e93ed85a2ab31245fc1d0b031740633ea5978d03714ddd9bL91-R107) [[3]](diffhunk://#diff-eb017d9680d95f37e93ed85a2ab31245fc1d0b031740633ea5978d03714ddd9bR119-R124) [[4]](diffhunk://#diff-eb017d9680d95f37e93ed85a2ab31245fc1d0b031740633ea5978d03714ddd9bR163-R171)
* Updated the HUD CSS generation to use these new config values, replacing the previous dependency on `StyleConfig` (`src/ui/hud.rs`). [[1]](diffhunk://#diff-4908d5a3253b23d83b5e66c5d06b216f03d1b1423d6c18c0a412ccdfde55deccL40-L123) [[2]](diffhunk://#diff-4908d5a3253b23d83b5e66c5d06b216f03d1b1423d6c18c0a412ccdfde55deccL238-R197) [[3]](diffhunk://#diff-4908d5a3253b23d83b5e66c5d06b216f03d1b1423d6c18c0a412ccdfde55deccL321-R279) [[4]](diffhunk://#diff-4908d5a3253b23d83b5e66c5d06b216f03d1b1423d6c18c0a412ccdfde55deccL392-R352) [[5]](diffhunk://#diff-4908d5a3253b23d83b5e66c5d06b216f03d1b1423d6c18c0a412ccdfde55deccL424-R385) [[6]](diffhunk://#diff-4908d5a3253b23d83b5e66c5d06b216f03d1b1423d6c18c0a412ccdfde55deccR401-R409)

**Settings UI Enhancements:**

* Added a new "HUD Appearance" section to the HUD settings page, allowing users to adjust opacity, border radius, and font size interactively. Changes are saved to the config and reflected live (`src/ui/settings/hud.rs`).

**Code Cleanup:**

* Removed the unused import of `StyleConfig` from `src/ui/hud.rs` as it is no longer needed.