### PR TITLE
feat: implement window toggle functionality for hyprkcs overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ cargo build --release
 
 Launch `hyprkcs` from your application menu or terminal to open the main window. Because it runs as a **Layer-Shell Overlay**, it may not appear as a traditional window in your taskbar or overview, but it will always be on top of your windows for quick access.
 
+Launching `hyprkcs` again while it is already open will toggle the existing overlay closed. This provides a reliable keyboard-only way to dismiss it without depending on your compositor's `killactive` behavior for layer-shell surfaces.
+
 **Keyboard Shortcuts**
 | Key | Action |
 | --- | --- |

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -13,9 +13,28 @@ use std::rc::Rc;
 
 type FilterCallback = std::rc::Rc<std::cell::RefCell<Option<Box<dyn Fn()>>>>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivationAction {
+    BuildNewWindow,
+    CloseExistingWindow,
+}
+
+fn activation_action(has_active_window: bool) -> ActivationAction {
+    if has_active_window {
+        ActivationAction::CloseExistingWindow
+    } else {
+        ActivationAction::BuildNewWindow
+    }
+}
+
 pub fn build_ui(app: &adw::Application) {
-    if let Some(window) = app.active_window() {
-        window.present();
+    if matches!(
+        activation_action(app.active_window().is_some()),
+        ActivationAction::CloseExistingWindow
+    ) {
+        if let Some(window) = app.active_window() {
+            window.close();
+        }
         return;
     }
 
@@ -1286,4 +1305,22 @@ pub fn build_ui(app: &adw::Application) {
 
     window.present();
     search_entry.grab_focus();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{activation_action, ActivationAction};
+
+    #[test]
+    fn activation_builds_window_when_none_is_open() {
+        assert_eq!(activation_action(false), ActivationAction::BuildNewWindow);
+    }
+
+    #[test]
+    fn activation_toggles_existing_window_closed() {
+        assert_eq!(
+            activation_action(true),
+            ActivationAction::CloseExistingWindow
+        );
+    }
 }


### PR DESCRIPTION
This pull request improves the user experience when launching the `hyprkcs` overlay by making repeated launches toggle the overlay closed, providing a more intuitive and keyboard-friendly way to dismiss it. Additionally, the code is refactored for clarity and reliability, and new unit tests are added to ensure the correct activation behavior.

**User experience improvements:**
* Launching `hyprkcs` while it is already open now toggles (closes) the existing overlay, making dismissal easier without relying on compositor-specific behavior. (`README.md`)

**Code refactoring and reliability:**
* Introduced the `ActivationAction` enum and the `activation_action` function to clearly distinguish between building a new window and closing an existing one, improving code clarity and maintainability. (`src/ui/window.rs`)

**Testing:**
* Added unit tests for the activation logic to ensure correct behavior when toggling the overlay. (`src/ui/window.rs`)

Fixing issue #74 