### PR TITLE
feat: add environment variable expansion support in path resolution

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -70,6 +70,78 @@ fn expand_tilde(path_str: &str) -> PathBuf {
     PathBuf::from(path_str)
 }
 
+fn expand_env_vars(input: &str) -> String {
+    if !input.contains('$') {
+        return input.to_string();
+    }
+
+    let chars: Vec<char> = input.chars().collect();
+    let mut result = String::with_capacity(input.len());
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] != '$' {
+            result.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        if i + 1 >= chars.len() {
+            result.push('$');
+            break;
+        }
+
+        if chars[i + 1] == '{' {
+            let mut j = i + 2;
+            while j < chars.len() && chars[j] != '}' {
+                j += 1;
+            }
+
+            if j < chars.len() {
+                let name: String = chars[i + 2..j].iter().collect();
+                if !name.is_empty() {
+                    if let Ok(value) = std::env::var(&name) {
+                        result.push_str(&value);
+                    } else {
+                        result.push('$');
+                        result.push('{');
+                        result.push_str(&name);
+                        result.push('}');
+                    }
+                    i = j + 1;
+                    continue;
+                }
+            }
+
+            result.push('$');
+            i += 1;
+            continue;
+        }
+
+        if chars[i + 1].is_ascii_alphabetic() || chars[i + 1] == '_' {
+            let mut j = i + 2;
+            while j < chars.len() && (chars[j].is_ascii_alphanumeric() || chars[j] == '_') {
+                j += 1;
+            }
+
+            let name: String = chars[i + 1..j].iter().collect();
+            if let Ok(value) = std::env::var(&name) {
+                result.push_str(&value);
+            } else {
+                result.push('$');
+                result.push_str(&name);
+            }
+            i = j;
+            continue;
+        }
+
+        result.push('$');
+        i += 1;
+    }
+
+    result
+}
+
 fn is_glob_pattern(s: &str) -> bool {
     s.contains('*') || s.contains('?') || s.contains('[')
 }
@@ -138,7 +210,7 @@ fn expand_path(
     vars: &HashMap<String, String>,
     sorted_keys: &[String],
 ) -> PathBuf {
-    let resolved_path_str = resolve_variables(path_str, vars, sorted_keys);
+    let resolved_path_str = expand_env_vars(&resolve_variables(path_str, vars, sorted_keys));
     let path_str = resolved_path_str.trim();
 
     if path_str.starts_with('~') {

--- a/tests/path_expansion_tests.rs
+++ b/tests/path_expansion_tests.rs
@@ -95,3 +95,54 @@ fn test_variable_expansion_in_source() {
     assert_eq!(binds.len(), 1);
     assert_eq!(binds[0].key.as_ref(), "V");
 }
+
+#[test]
+fn test_env_var_expansion_in_source_path() {
+    let _guard = lock_env();
+    let temp_dir = TempDir::new();
+
+    let main_conf = temp_dir.path.join("hyprland.conf");
+    let nested_dir = temp_dir.path.join("nested");
+    fs::create_dir(&nested_dir).expect("Failed to create nested dir");
+    let nested_conf = nested_dir.join("included.conf");
+
+    std::env::set_var("HYPRKCS_TEST_SOURCE_ROOT", &temp_dir.path);
+    fs::write(
+        &main_conf,
+        "source = $HYPRKCS_TEST_SOURCE_ROOT/nested/included.conf",
+    )
+    .expect("Failed to write main");
+    fs::write(&nested_conf, "bind = SUPER, H, exec, env_works").expect("Failed to write nested");
+
+    std::env::set_var("HYPRKCS_CONFIG", &temp_dir.path);
+
+    let binds = parse_config().expect("Failed to parse config");
+    assert_eq!(binds.len(), 1);
+    assert_eq!(binds[0].key.as_ref(), "H");
+}
+
+#[test]
+fn test_braced_env_var_expansion_in_source_path() {
+    let _guard = lock_env();
+    let temp_dir = TempDir::new();
+
+    let main_conf = temp_dir.path.join("hyprland.conf");
+    let nested_dir = temp_dir.path.join("nested");
+    fs::create_dir(&nested_dir).expect("Failed to create nested dir");
+    let nested_conf = nested_dir.join("included.conf");
+
+    std::env::set_var("HYPRKCS_TEST_SOURCE_ROOT_BRACED", &temp_dir.path);
+    fs::write(
+        &main_conf,
+        "source = ${HYPRKCS_TEST_SOURCE_ROOT_BRACED}/nested/included.conf",
+    )
+    .expect("Failed to write main");
+    fs::write(&nested_conf, "bind = SUPER, B, exec, braced_env_works")
+        .expect("Failed to write nested");
+
+    std::env::set_var("HYPRKCS_CONFIG", &temp_dir.path);
+
+    let binds = parse_config().expect("Failed to parse config");
+    assert_eq!(binds.len(), 1);
+    assert_eq!(binds[0].key.as_ref(), "B");
+}


### PR DESCRIPTION
This pull request introduces support for expanding environment variables in source paths, enhancing the flexibility and usability of the configuration parser. The main changes include the implementation of an environment variable expansion function, integration of this logic into path resolution, and the addition of comprehensive tests to ensure correct behavior.

**Environment Variable Expansion:**

* Added a new `expand_env_vars` function to handle expansion of environment variables (both `$VAR` and `${VAR}` formats) in path strings in `src/parser/mod.rs`.
* Updated the `expand_path` function to apply environment variable expansion when resolving paths, ensuring that any environment variables present in configuration paths are correctly substituted.

**Testing:**

* Added new tests `test_env_var_expansion_in_source_path` and `test_braced_env_var_expansion_in_source_path` in `tests/path_expansion_tests.rs` to verify that environment variable expansion works as expected for both standard and braced variable formats in source paths.

Fix for #73 